### PR TITLE
fix hash generation regression from Swift 3 conversion

### DIFF
--- a/Hashids.swift
+++ b/Hashids.swift
@@ -227,7 +227,7 @@ open class Hashids_<T>: HashidsGenerator where T:Equatable, T:UnsignedInteger {
       let rrange = Range<Int>(half_length ..< (alphabet.count))
       let alphabet_right = alphabet[rrange]
       let alphabet_left = alphabet[lrange]
-      hash = Array<Char>(alphabet_left) + hash + Array<Char>(alphabet_right)
+      hash = Array<Char>(alphabet_right) + hash + Array<Char>(alphabet_left)
 
       let excess = hash.count - minLength
       if excess > 0 {

--- a/Tests/HashidsTests/HashidsTests.swift
+++ b/Tests/HashidsTests/HashidsTests.swift
@@ -58,6 +58,30 @@ class HashIdsTests: XCTestCase {
     XCTAssertEqual(equalCount, knownHashes.count)
   }
 
+  func testKnownHashesWithHashLengthAndAlphabet() {
+      // known hashes where generated with js Hashids implementation
+      // http://codepen.io/anon/pen/MbmpJP
+      let knownHashes: [String:[Int]] = [
+          "GlaHquq0": [1, 2, 3],
+          "gB0NV05e": [1],
+          "xJ3MBFkB3PO": [123456, 123456789],
+          "NZFzBrjhl": [10, 123456, 1]
+      ]
+
+      var equalCount = 0
+      let hashids = Hashids(salt: "this is my salt", minHashLength: 8, alphabet: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890")
+      for expectedHash in knownHashes.keys {
+          let values = knownHashes[expectedHash]
+          if let hash = hashids.encode(values!) {
+              if (hash == expectedHash) {
+                  equalCount += 1
+              }
+          }
+      }
+      
+      XCTAssertEqual(equalCount, knownHashes.count)
+  }
+
   func testHashMinLength() {
     let minHashLength = 20
     let testRange = 1 ... 20


### PR DESCRIPTION
I was comparing the changes from the swift-2.3 branch to the master branch and it looks like order the alphabet was being used got reversed (https://github.com/malczak/hashids/blob/swift-2.3/Hashids.swift#L226). This PR fixes that and adds a test to check known hashes that include a hash length and alphabet. This should fix #10.