### PR TITLE
Updated to Swift 4.2

### DIFF
--- a/Hashids.swift
+++ b/Hashids.swift
@@ -223,8 +223,8 @@ open class Hashids_<T>: HashidsGenerator where T:UnsignedInteger {
     let half_length = alphabet.count >> 1
     while hash.count < minLength {
       shuffle(&alphabet, alphabet)
-      let lrange = Range<Int>(0 ..< half_length)
-      let rrange = Range<Int>(half_length ..< (alphabet.count))
+      let lrange = 0 ..< half_length
+      let rrange = half_length ..< (alphabet.count)
       let alphabet_right = alphabet[rrange]
       let alphabet_left = alphabet[lrange]
       hash = Array<Char>(alphabet_right) + hash + Array<Char>(alphabet_left)
@@ -307,7 +307,7 @@ open class Hashids_<T>: HashidsGenerator where T:UnsignedInteger {
     salt = salt + alphabet
     let lsaltARange = (self.salt.count + 1) ..< salt.count
     let lsaltRange = 0 ..< alphabet.count
-    return (Range<Int>(lsaltARange), Range<Int>(lsaltRange))
+    return (lsaltARange, lsaltRange)
   }
 
 }


### PR DESCRIPTION
Swift 4: 'init' is deprecated. CountableRange is now Range
https://github.com/apple/swift-evolution/blob/master/proposals/0172-one-sided-ranges.md