### PR TITLE
Fix Double -> Int overflow that can cause crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ DerivedData
 #
 Pods/
 Podfile.lock
+
+Packages
+.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+	name: "hashids",
+	products: [
+		.library(name: "hashids", targets: ["hashids"]),
+	],
+	dependencies: [],
+	targets: [
+		.target(name: "hashids", dependencies: []),
+		.testTarget(name: "HashidsTests", dependencies: ["hashids"])
+	]
+)

--- a/Tests/HashidsTests/HashidsTests.swift
+++ b/Tests/HashidsTests/HashidsTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Hashids_Swift
+import hashids
 
 class HashIdsTests: XCTestCase {
     
@@ -186,7 +186,14 @@ class HashIdsTests: XCTestCase {
         let hashids = Hashids(salt: "this is my salt")
         let hash = hashids.encode(input)
         let values = hashids.decode64(hash!)
-        XCTAssertEqual(input, values.first)
+        XCTAssertEqual(input, values!.first)
+    }
+    
+    func testDoubleOverflow() {
+        let hashOfMaxInt64 = "jvNx4BjM5KYjv"
+        let hashids = Hashids(salt: "this is my salt")
+        let values = hashids.decode64(hashOfMaxInt64) // Should not crash!
+        XCTAssertNil(values)
     }
     
 }


### PR DESCRIPTION
Today this library is unsafe. 

```swift
let hashOfMaxInt64 = "jvNx4BjM5KYjv" // untrusted input
let hashids = Hashids(salt: "this is my salt")
let values = hashids.decode64(hashOfMaxInt64) // 💥 Crash
```

A simple hash of `Int64.max` will crash when attempting to decode because the double overflows the integer during decoding. Personally, I think the `Double` -> `Int` constructor should return an optional since it can fail as this ends up being a foot-gun in an otherwise safe language. 

Because of how hashids work, it is impossible to know ahead of time if a given input is safe without first trying to decode it. If you run this library on a web server on untrusted input, you are at risk of a crash and **should patch immediately**.

This PR fixes the issue and adds swift package support. Since it appears this repo is no longer accepting PRs, I will leave my fork up for others to use including this bug fix: https://github.com/gh123man/hashids